### PR TITLE
Use root namespace for context and params

### DIFF
--- a/src/crouter/router.cr
+++ b/src/crouter/router.cr
@@ -41,7 +41,7 @@ module Crouter
             \{% controller = action.split("#")[0] %}
             \{% action = action.split("#")[1] %}
             \{% raise(action_error) unless controller && action %}
-            \{% action = "-> (context : HTTP::Server::Context, params : HTTP::Params) { controller = #{controller.id}.new(context, params); controller.#{action.id}; nil }" %}
+            \{% action = "-> (context : ::HTTP::Server::Context, params : ::HTTP::Params) { controller = #{controller.id}.new(context, params); controller.#{action.id}; nil }" %}
           \{% elsif !action.is_a?(ProcLiteral) %}
              \{% raise(action_error) %}
           \{% end %}
@@ -51,7 +51,7 @@ module Crouter
         end
 
         macro {{method.downcase.id}}(pattern)
-          \{% action = "-> (context : HTTP::Server::Context, params : HTTP::Params) { #{yield}; nil }" %}
+          \{% action = "-> (context : ::HTTP::Server::Context, params : ::HTTP::Params) { #{yield}; nil }" %}
           {{method.downcase.id}}(\{{pattern}}, \{{action.id}})
         end
       {% end %}


### PR DESCRIPTION
I noticed that when I tried to implement a router within a namespace I wasn't able to compile it.

```
require "./router"
^

in src/router/router.cr:6: expanding macro

    get "/" do
    ^~~

in src/router/router.cr:6: expanding macro

    get "/" do
    ^

in macro 'get' expanded macro: inherited:44, line 2:

   1.           
>  2.           get("/", -> (context : HTTP::Server::Context, params : HTTP::Params) { context.response << "hello world"; nil })
   3.         

expanding macro
in macro 'get' expanded macro: inherited:44, line 2:

   1.           
>  2.           get("/", -> (context : HTTP::Server::Context, params : HTTP::Params) { context.response << "hello world"; nil })
   3.         

expanding macro
in macro 'get' expanded macro: inherited:29, line 5:

   1.           
   2.           
   3.           
   4.           ROUTES["#{Crouter::Route.prefix}/".gsub(/(\:|\(|\/$).*/, "")] ||= [] of Crouter::Route
>  5.           ROUTES["#{Crouter::Route.prefix}/".gsub(/(\:|\(|\/$).*/, "")] << Crouter::Route.new("GET", "/", ->(context : HTTP::Server::Context, params : HTTP::Params) do
   6.   context.response << "hello world"
   7.   nil
   8. end)
   9.         

undefined constant HTTP::Server::Context
```

I believe that when the macro is applied it can no longer find `HTTP::Server::Context` or `HTTP::Params` relatively. When I made this change locally it appeared to work and I was able to put my router in it's own namespace.